### PR TITLE
Create Deck, Edit Deck, Retrieve Deck, Efficiencies

### DIFF
--- a/requests/card.js
+++ b/requests/card.js
@@ -6,7 +6,7 @@ const supabase = createClient(
 )
 
 // Database References
-const limitedData = 'id, name, artist, border_color, card_faces, cmc, color_identity, colors, digital, finishes, flavor_text, frame, frame_effects, full_art, image_uris, lang, layout, legalities, mana_cost, oracle_text, power, promo, rarity, released_at, set_name, set_shorthand, set_type, toughness, type_one, type_two, subtype_one, subtype_two'
+const limitedData = 'id, name, artist, border_color, card_faces, cmc, color_identity, colors, digital, finishes, flavor_text, frame, frame_effects, full_art, games, image_uris, lang, layout, legalities, mana_cost, oracle_text, power, promo, rarity, released_at, set_name, set_shorthand, set_type, toughness, type_one, type_two, subtype_one, subtype_two'
 const atcMaster = 'atc_cards_master'
 const decksMaster = 'atc_decks_master'
 const deckMaster = 'atc_deck_master'

--- a/routes/api.js
+++ b/routes/api.js
@@ -49,6 +49,13 @@ router.post('/features/editor/decks', async function (req, res, next) {
 
 });
 
+// Deck Editor Retrieve
+router.post('/features/editor/retrieve', async function (req, res, next) {
+
+  res.json(await deckRequests.editDeck(req))
+
+});
+
 
 // Basic Deck Search Query
 router.post('/search/deck/query=:queryDeck', async function (req, res, next) {


### PR DESCRIPTION
- Added games to limitedData.
- Modified deckID query to include additional information (description, tags).
- Removed username[] reliance in multiple deck queries.
- Added createDeck() function to desk.js.
- Handles wipDeck from client to either create a new deck or update an existing one.
- This is based on whether the deckID key is populated or not.
- It will either return a message or an error so client is informed.
- Added editDeck() function to deck.js.
- Handles deckID request from client to retrieve a formatted wipDeck.
- It will either return a wipDeck or an error if the deckID is invalid.
- Added deck editor retrieve route in api.js.
- Route 'api/features/editor/retrieve' is for wipDeck retrieval.