### PR TITLE
Custom Card Edit and Delete

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -88,6 +88,14 @@ router.post('/features/editor/cards', upload.fields([{name: 'art_crop'}, {name: 
 });
 
 
+// Card Editor Delete
+router.delete('/features/editor/card-delete', async function (req, res, next) {
+
+  res.json(await cardRequests.deleteCard(req))
+
+});
+
+
 // Basic Deck Search Query
 router.post('/search/deck/query=:queryDeck', async function (req, res, next) {
 


### PR DESCRIPTION
- Added removeCardArt() to card.js to assist in removing old card art when a custom card is edited.
- Added field validation to the card editor request. Now validates quite a few fields.
- Added appropriate error messages for missing fields to be returned to user.
- Implemented ability to update an existing custom card, all that is needed is an id field to be populated.
- Images will be necessary again as a result of this.
- There is a fix in place for any decks that may have this card as a cover card, they get updated appropriately.
- Added deleteCard() function to card.js.
- Users have the ability to delete their own custom cards.
- This is mostly completed. There remain two outstanding calls to be made (custom table deletion, deck cover art fix).
- For now, the custom art is unaffected as the actual card deletion does not take place yet.
- Requires the access token and cardId in the headers.
- Added card deletion route in api.js.
- Route 'api/features/editor/card-delete' is for the card deletion call.
- This route is a DELETE method.